### PR TITLE
Fix Sigma16 CMakeLists.txt

### DIFF
--- a/llvm/lib/Target/Sigma16/CMakeLists.txt
+++ b/llvm/lib/Target/Sigma16/CMakeLists.txt
@@ -22,6 +22,7 @@ add_llvm_target(Sigma16CodeGen
   Sigma16InstrInfo.cpp
   Sigma16ISelLowering.cpp
   Sigma16MachineFunction.cpp
+  Sigma16MCInstLower.cpp
   Sigma16RegisterInfo.cpp
   Sigma16SEFrameLowering.cpp
   Sigma16SEInstrInfo.cpp


### PR DESCRIPTION
One of the files was missing from the list of llvm components.
