### PR TITLE
Fix incorrect default for CCache in CMake variants

### DIFF
--- a/.vscode/cmake-variants.json
+++ b/.vscode/cmake-variants.json
@@ -31,7 +31,7 @@
         }
     },
     "UseCCache": {
-        "default": "No CCache",
+        "default": "no",
         "choices": {
             "yes": {
                 "short": "CCache",


### PR DESCRIPTION
The short value rather than the JSON key was being used.
