### PR TITLE
Fix CMake bug when building for Sigma16

### DIFF
--- a/.vscode/cmake-variants.json
+++ b/.vscode/cmake-variants.json
@@ -90,6 +90,9 @@
                 "short": "Sigma16",
                 "long": "The Sigma16 Architecture",
                 "settings": {
+                    "LLVM_TARGETS_TO_BUILD": [
+                        "X86"
+                    ],
                     "LLVM_EXPERIMENTAL_TARGETS_TO_BUILD": [
                         "Sigma16"
                     ]


### PR DESCRIPTION
At least one target in LLVM_TARGETS_TO_BUILD must be provided, otherwise all possible targets will be configured to be built.
